### PR TITLE
Fix OpenAPI comments for Invoice module

### DIFF
--- a/modules/invoice/api/invoice-routes.ts
+++ b/modules/invoice/api/invoice-routes.ts
@@ -25,7 +25,9 @@ module.exports = function (app: core.Express) {
    *      '200':
    *        description: OK
    *        schema:
-   *          $ref: '#/definitions/MockInvoiceResponse'
+   *          type: array
+   *          items:
+   *            $ref: '#/definitions/MockInvoiceResponse'
    */
   app.get('/invoices/:qty?', (req: Request, res: Response) => {
     const qty = getQtyFromRequest(req, DEFAULT_INVOICE_QUANTITY);


### PR DESCRIPTION
Hi! In my last PR #117 , I made a mistake, I wrote that the endpoint would return an object type Invoice but that must return an array of Invoice.