### PR TITLE
Add Open API comments and tests for time zones

### DIFF
--- a/modules/time_zones/api/timezones-routes.ts
+++ b/modules/time_zones/api/timezones-routes.ts
@@ -4,6 +4,21 @@ import time_zones from '../data/time_zones';
 
 module.exports = function(app : core.Express){
 
+    /**
+     * @openapi
+     * "/time-zones":
+     *  get:
+     *    tags:
+     *      - TimeZones
+     *    summary: Get all time zones
+     *    responses:
+     *      '200':
+     *        description: OK
+     *        schema:
+     *          type: array
+     *          items:
+     *            $ref: '#/definitions/MockTimeZoneResponse'
+     */
     // Get all time_zones
     app.get("/time-zones", (req: Request, res: Response) => {
         res.json(time_zones)

--- a/modules/time_zones/api/timezones-routes.ts
+++ b/modules/time_zones/api/timezones-routes.ts
@@ -5,13 +5,13 @@ import time_zones from '../data/time_zones';
 module.exports = function(app : core.Express){
 
     // Get all time_zones
-    app.get("/time_zones", (req: Request, res: Response) => {
+    app.get("/time-zones", (req: Request, res: Response) => {
         res.json(time_zones)
 
     })
 
     // Get a random quote
-    app.get("/time_zones/random", (req: Request, res: Response) => {
+    app.get("/time-zones/random", (req: Request, res: Response) => {
         const time_zone = time_zones[Math.floor(Math.random() * time_zones.length)];
         res.json(time_zone)
     })

--- a/modules/time_zones/api/timezones-routes.ts
+++ b/modules/time_zones/api/timezones-routes.ts
@@ -25,6 +25,19 @@ module.exports = function(app : core.Express){
 
     })
 
+    /**
+     * @openapi
+     * "/time-zones/random":
+     *  get:
+     *    tags:
+     *      - TimeZones
+     *    summary: Get random time zone
+     *    responses:
+     *      '200':
+     *        description: OK
+     *        schema:
+     *          $ref: '#/definitions/MockTimeZoneResponse'
+     */
     // Get a random quote
     app.get("/time-zones/random", (req: Request, res: Response) => {
         const time_zone = time_zones[Math.floor(Math.random() * time_zones.length)];

--- a/modules/time_zones/consts/TimeZone.ts
+++ b/modules/time_zones/consts/TimeZone.ts
@@ -1,0 +1,35 @@
+/**
+ * @openapi
+ * definitions:
+ *  MockTimeZoneResponse:
+ *    type: object
+ *    properties:
+ *      value:
+ *        type: string
+ *        example: America/New_York
+ *      abbr:
+ *        type: string
+ *        example: EST
+ *      offset:
+ *        type: number
+ *        example: -5
+ *      isdst:
+ *        type: boolean
+ *        example: true
+ *      text:
+ *        type: string
+ *        example: '(GMT-05:00) Eastern Time (US & Canada)'
+ *      utc:
+ *        type: array
+ *        items:
+ *          type: string
+ *          example: 'America/New_York'
+ */
+type TimeZone = {
+  value: string;
+  abbr: string;
+  offset: number;
+  isdst: boolean;
+  text: string;
+  utc: string[];
+}

--- a/modules/time_zones/tests/api/timezones-routes.test.ts
+++ b/modules/time_zones/tests/api/timezones-routes.test.ts
@@ -1,0 +1,34 @@
+import request from 'supertest';
+
+const baseURL = 'http://localhost:3000';
+
+describe('GET /timezones/', () => {
+  it('should return 200 OK', async () => {
+    const response = await request(baseURL).get('/time-zones');
+    const timeZone = response.body[0];
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBeInstanceOf(Array);
+    expect(timeZone).toHaveProperty('value');
+    expect(timeZone).toHaveProperty('abbr');
+    expect(timeZone).toHaveProperty('offset');
+    expect(timeZone).toHaveProperty('isdst');
+    expect(timeZone).toHaveProperty('text');
+    expect(timeZone).toHaveProperty('utc');
+  });
+});
+
+describe('GET /timezones/random', () => {
+  it('should return 200 OK', async () => {
+    const response = await request(baseURL).get('/time-zones/random');
+    const timeZone = response.body;
+
+    expect(response.status).toBe(200);
+    expect(timeZone).toHaveProperty('value');
+    expect(timeZone).toHaveProperty('abbr');
+    expect(timeZone).toHaveProperty('offset');
+    expect(timeZone).toHaveProperty('isdst');
+    expect(timeZone).toHaveProperty('text');
+    expect(timeZone).toHaveProperty('utc');
+  });
+});


### PR DESCRIPTION
I added OpenAPI comments and tests for the time zones module. Also I change URL from /time_zone/ to /time-zone/, from my point of view is a better practice.