### PR TITLE
faulting tests are now using supertest correctly

### DIFF
--- a/modules/address/tests/api/address-routes.test.ts
+++ b/modules/address/tests/api/address-routes.test.ts
@@ -1,12 +1,11 @@
+import app from "../../../../app";
 let request = require('supertest');
-
-const baseUrl = 'http://localhost:13000';
 
 // address-routes.ts tests
 describe('GET /address/', () => {
 	it('should return a random address', async () => {
 
-		const response = await request(baseUrl)
+		const response = await request(app)
 			.get('/address');
 		
 		const {status, body} = response;
@@ -20,7 +19,7 @@ describe('GET /address/', () => {
 // address/:country
 describe('GET /address/:country', () => {
 	it('should return a random USA format address', async () => {
-		const response = await request(baseUrl)
+		const response = await request(app)
 			.get('/address/usa');
 
 		const {status, body} = response;
@@ -31,7 +30,7 @@ describe('GET /address/:country', () => {
 	})
 
 	it('should return a random UK format address', async () => {
-		const response = await request(baseUrl)
+		const response = await request(app)
 			.get('/address/uk');
 
 		const {status, body} = response;
@@ -45,7 +44,7 @@ describe('GET /address/:country', () => {
 // address/:country/:qty
 describe('GET /address/:country/:qty', () => {
 	it('should return given number of random USA format addresses', async () => {
-		const response = await request(baseUrl)
+		const response = await request(app)
 			.get('/address/usa/5');
 
 		const {status, body} = response;
@@ -60,7 +59,7 @@ describe('GET /address/:country/:qty', () => {
 	})
 
 	it('should return given number of random UK format addresses', async () => {
-		const response = await request(baseUrl)
+		const response = await request(app)
 			.get('/address/uk/5');
 
 		const {status, body} = response;

--- a/modules/bankfeed/tests/api/bankfeed-routes.test.ts
+++ b/modules/bankfeed/tests/api/bankfeed-routes.test.ts
@@ -1,12 +1,12 @@
-import request from 'supertest';
-const baseURL = 'http://localhost:3000';
+import app from "../../../../app";
+let request = require('supertest');
 
 describe('bank feed api endpoints', () => {
     describe('GET /bank/feed/:qty', () => {
         it('should return a list of bank statement', async () => {
             const qty = 5;
 
-            const response = await request(baseURL).get(`/bank/feed/${qty}`);
+            const response = await request(app).get(`/bank/feed/${qty}`);
             const bankData = response.body;
             const bankStatement = bankData.statement[0]
 

--- a/modules/ecommerce/tests/api/ecommerce-routes.test.ts
+++ b/modules/ecommerce/tests/api/ecommerce-routes.test.ts
@@ -1,10 +1,10 @@
-const request = require('supertest');
-const baseURL = 'http://localhost:3000';
+import app from "../../../../app";
+let request = require('supertest');
 
 describe('ecommerce api endpoints', () => {
   describe('GET /ecommerce/cart', () => {
     it('should return a random cart with random products', async () => {
-      const response = await request(baseURL).get(`/ecommerce/cart`);
+      const response = await request(app).get(`/ecommerce/cart`);
       
       const cart = response.body;
 
@@ -35,7 +35,7 @@ describe('ecommerce api endpoints', () => {
     const qty = 2;
 
     it('should return a random cart with the given quantity of products', async () => {
-      const response = await request(baseURL).get(`/ecommerce/cart/${qty}`);
+      const response = await request(app).get(`/ecommerce/cart/${qty}`);
       expect(response.body.products.length).toEqual(qty);
     });
   });

--- a/modules/location/test/api/location-routes.test.ts
+++ b/modules/location/test/api/location-routes.test.ts
@@ -1,12 +1,12 @@
-import request from 'supertest';
-const baseURL = 'http://localhost:3000';
+import app from "../../../../app";
+let request = require('supertest');
 
 // Test case: for random coordinates is returned check
 describe('random coordinates api endpoints', () => {
     describe('GET /location/co-ordinates/random/:qty', () => {
         it('should return a one random coordinates', async () => {
             const qty = 1;
-            const response = await request(baseURL).get(`/location/co-ordinates/random/${qty}`);
+            const response = await request(app).get(`/location/co-ordinates/random/${qty}`);
             const coordinates = response.body[0];
             expect(coordinates).toHaveProperty('latitude');
             expect(coordinates).toHaveProperty('longitude');
@@ -21,7 +21,7 @@ describe('coordinates for country code', () => {
         it('should return a one random coordinate in specified country', async () => {
             const code = 'US';
             const qty = 1;
-            const response = await request(baseURL).get(`/location/co-ordinates/country/${code}/${qty}`);
+            const response = await request(app).get(`/location/co-ordinates/country/${code}/${qty}`);
             const coordinates = response.body[0];
             expect(coordinates).toHaveProperty('latitude');
             expect(coordinates).toHaveProperty('longitude');

--- a/modules/products/test/api/products-routes.test.ts
+++ b/modules/products/test/api/products-routes.test.ts
@@ -20,7 +20,7 @@ describe('products api endpoints', () => {
         const rating = 2;
 
         it('should return a list of reviews ', async () => {
-            const response = await request(baseURL).get(`/products/reviews/ratings/${rating}`);
+            const response = await request(app).get(`/products/reviews/ratings/${rating}`);
             expect(response.body[0].rating).toEqual(rating);
             expect(response.body[0]).toHaveProperty('productName');
             expect(response.body[0]).toHaveProperty('productId');
@@ -37,7 +37,7 @@ describe('products api endpoints', () => {
         const department = "Computer";
 
         it('should return a list of products ', async () => {
-            const response = await request(baseURL).get(`/products/${quantity}/${department}`);
+            const response = await request(app).get(`/products/${quantity}/${department}`);
             expect(response.body.length).toEqual(quantity);
             expect(response.body[0].department).toEqual(department);
             expect(response.body[0]).toHaveProperty('department');
@@ -54,7 +54,7 @@ describe('products api endpoints', () => {
         const quantity = 4;
 
         it('should return a list of products ', async () => {
-            const response = await request(baseURL).get(`/products/quantity/${quantity}`);
+            const response = await request(app).get(`/products/quantity/${quantity}`);
             expect(response.body.length).toEqual(quantity);
 
         });
@@ -64,7 +64,7 @@ describe('products api endpoints', () => {
         const department = "Computer";
 
         it('should return a list of products', async () => {
-            const response = await request(baseURL).get(`/products/department/${department}`);
+            const response = await request(app).get(`/products/department/${department}`);
             expect(response.body[0].department).toEqual(department);
 
         });
@@ -72,7 +72,7 @@ describe('products api endpoints', () => {
 
     describe('GET /product', () => {
         it('should return a random product ', async () => {
-            const response = await request(baseURL).get(`/product`);
+            const response = await request(app).get(`/product`);
             expect(response.body.length).toEqual(1);
             expect(response.body[0]).toHaveProperty('department');
             expect(response.body[0]).toHaveProperty('type');


### PR DESCRIPTION
PR for issue #192 
Tests that are generally not using supertest module correctly are now resolved, tests failures are now reduced to specific test errors and not module  usage error.

### Before:
![before](https://user-images.githubusercontent.com/77179231/194995372-279e9e9c-0829-4050-8ed8-95de4e815ab3.png)


### After:
![after](https://user-images.githubusercontent.com/77179231/194995397-2f9d2d19-54a9-471b-a84e-187d63533274.png)

