### PR TITLE
Add new chat feed mock

### DIFF
--- a/modules/chat/api/chat-routes.ts
+++ b/modules/chat/api/chat-routes.ts
@@ -1,37 +1,35 @@
-import { faker } from '@faker-js/faker';
-import { Request, Response } from 'express';
-import * as core from 'express-serve-static-core';
-import getRandomUsers from '../../users/utils/getRandomUsers';
-import { getRandomChat } from '../utils/getRandomChat';
+import { Request, Response } from 'express'
+import * as core from 'express-serve-static-core'
+import { getRandomChat } from '../utils/getRandomChat'
 
-const defaultUserCount = 100;
-const defaultMessageCount = 1000;
+const defaultUserCount = 100
+const defaultMessageCount = 1000
 
 module.exports = function (app: core.Express) {
-    /**
+  /**
      * @openapi
      * '/chat/random':
      *   get:
      *     tags:
      *       - Chat
-     *     summary: Returns a random chat of 100 users and 1000 messages using randomly generated sentances
+     *     summary: Returns a random chat of 100 users and 1000 messages of various length (word, sentences, paragraphs)
      *     responses:
      *       '200':
      *         description: OK
      *         schema:
      *           $ref: '#/definitions/MockChatResponse'
      */
-    app.get('/chat/random/', (req: Request, res: Response) => {
-        res.json(getRandomChat(defaultUserCount, defaultMessageCount));
-    });
+  app.get('/chat/random/', (req: Request, res: Response) => {
+    res.json(getRandomChat(defaultUserCount, defaultMessageCount))
+  })
 
-    /**
+  /**
      * @openapi
      * '/chat/random/{userCount}/{messageCount}':
      *   get:
      *     tags:
      *       - Chat
-     *     summary: Returns a random chat of messages from defined counts using randomly generated sentances
+     *     summary: Returns a random chat of messages from defined counts using randomly generated messages of various length (word, sentences, paragraphs)
      *     parameters:
      *       - in: path
      *         name: userCount
@@ -49,9 +47,9 @@ module.exports = function (app: core.Express) {
      *         schema:
      *           $ref: '#/definitions/MockChatResponse'
      */
-    app.get('/chat/random/:userCount/:messageCount', (req: Request, res: Response) => {
-        const userCount = req.params.userCount ? parseInt(req.params.userCount) : defaultUserCount;
-        const messageCount = req.params.messageCount ? parseInt(req.params.messageCount) : defaultMessageCount;
-        res.json(getRandomChat(userCount, messageCount));
-    });
-};
+  app.get('/chat/random/:userCount/:messageCount', (req: Request, res: Response) => {
+    const userCount = req.params.userCount ? parseInt(req.params.userCount) : defaultUserCount
+    const messageCount = req.params.messageCount ? parseInt(req.params.messageCount) : defaultMessageCount
+    res.json(getRandomChat(userCount, messageCount))
+  })
+}

--- a/modules/chat/api/chat-routes.ts
+++ b/modules/chat/api/chat-routes.ts
@@ -12,7 +12,7 @@ module.exports = function (app: core.Express) {
      *   get:
      *     tags:
      *       - Chat
-     *     summary: Returns a random chat of 100 users and 1000 messages of various length (word, sentences, paragraphs)
+     *     summary: Returns a random chat of 100 users and 1000 sentences
      *     responses:
      *       '200':
      *         description: OK
@@ -24,12 +24,59 @@ module.exports = function (app: core.Express) {
   })
 
   /**
+   * @openapi
+   * '/chat/random/various':
+   *   get:
+   *     tags:
+   *       - Chat
+   *     summary: Returns a random chat of 100 users and 1000 messages of various length
+   *     responses:
+   *       '200':
+   *         description: OK
+   *         schema:
+   *           $ref: '#/definitions/MockChatResponse'
+   */
+  app.get('/chat/random/various/', (req: Request, res: Response) => {
+    res.json(getRandomChat(defaultUserCount, defaultMessageCount, true))
+  })
+
+  /**
+   * @openapi
+   * '/chat/random/various/{userCount}/{messageCount}':
+   *   get:
+   *     tags:
+   *       - Chat
+   *     summary: Returns a random chat of messages from defined counts using randomly generated sentences
+   *     parameters:
+   *       - in: path
+   *         name: userCount
+   *         description: The amount of users the messages can be generated from
+   *         type: string
+   *         default: 100
+   *       - in: path
+   *         name: messageCount
+   *         description: The amount of messages that will be returned
+   *         type: string
+   *         default: 1000
+   *     responses:
+   *       '200':
+   *         description: OK
+   *         schema:
+   *           $ref: '#/definitions/MockChatResponse'
+   */
+  app.get('/chat/random/various/:userCount/:messageCount', (req: Request, res: Response) => {
+    const userCount = req.params.userCount !== '' ? parseInt(req.params.userCount) : defaultUserCount
+    const messageCount = req.params.messageCount !== '' ? parseInt(req.params.messageCount) : defaultMessageCount
+    res.json(getRandomChat(userCount, messageCount, true))
+  })
+
+  /**
      * @openapi
      * '/chat/random/{userCount}/{messageCount}':
      *   get:
      *     tags:
      *       - Chat
-     *     summary: Returns a random chat of messages from defined counts using randomly generated messages of various length (word, sentences, paragraphs)
+     *     summary: Returns a random chat of messages from defined counts using randomly generated sentences
      *     parameters:
      *       - in: path
      *         name: userCount

--- a/modules/chat/tests/api/chat-routes.test.ts
+++ b/modules/chat/tests/api/chat-routes.test.ts
@@ -1,33 +1,56 @@
-import request from 'supertest';
-import app from '../../../../app';
+import request from 'supertest'
+import app from '../../../../app'
 // const app = 'http://localhost:3000';
 
+const testDefaultRoutes = (response: request.Response): void => {
+  expect(response.body.messages.length).toBe(1000)
+  expect(response.body.messages[0]).toHaveProperty('id')
+  expect(response.body.messages[0]).toHaveProperty('createdAt')
+  expect(response.body.messages[0]).toHaveProperty('message')
+  expect(response.body.messages[0]).toHaveProperty('userId')
+}
+
+const testParametizedRoutes = (response: request.Response, userCount: number, messageCount: number): void => {
+  const userSet = new Set()
+
+  response.body.users.forEach((element) => {
+    userSet.add(element.userId)
+  })
+
+  expect(response.body.messages.length).toBe(messageCount)
+  expect(userSet.size).toBe(userCount)
+}
+
 describe.only('chat api endpoints', () => {
-    describe('GET /chat/random', () => {
-        it('should return a random chat snapshot with 1000 messages', async () => {
-            const response = await request(app).get(`/chat/random`);
-            expect(response.body.messages.length).toBe(1000);
-            expect(response.body.messages[0]).toHaveProperty('id');
-            expect(response.body.messages[0]).toHaveProperty('createdAt');
-            expect(response.body.messages[0]).toHaveProperty('message');
-            expect(response.body.messages[0]).toHaveProperty('userId');
-        });
-    });
+  describe('GET /chat/random', () => {
+    it('should return a random chat snapshot with 1000 messages', async () => {
+      const response = await request(app).get('/chat/random')
+      testDefaultRoutes(response)
+    })
+  })
 
-    describe('GET /chat/random/:userCount/:messageCount', () => {
-        it('should return a chat with the correct message and user count', async () => {
-            const userCount = 5;
-            const messageCount = 100;
-            const response = await request(app).get(`/chat/random/${userCount}/${messageCount}`);
+  describe('GET /chat/random/various', () => {
+    it('should return a random chat snapshot with 1000 messages', async () => {
+      const response = await request(app).get('/chat/random/various')
+      testDefaultRoutes(response)
+    })
+  })
 
-            const userSet = new Set();
+  describe('GET /chat/random/:userCount/:messageCount', () => {
+    it('should return a chat with the correct message and user count', async () => {
+      const userCount = 5
+      const messageCount = 100
+      const response = await request(app).get(`/chat/random/${userCount}/${messageCount}`)
+      testParametizedRoutes(response, userCount, messageCount)
+    })
+  })
 
-            response.body.users.forEach((element) => {
-                userSet.add(element.userId);
-            });
-
-            expect(response.body.messages.length).toBe(messageCount);
-            expect(userSet.size).toBe(userCount);
-        });
-    });
-});
+  describe('GET /chat/random/various/:userCount/:messageCount', () => {
+    it('should return a chat with the correct message and user count', async () => {
+      const userCount = 5
+      const messageCount = 100
+      const response = await request(app).get(`/chat/random/various/${userCount}/${messageCount}`)
+      testParametizedRoutes(response, userCount, messageCount)
+    })
+  })
+})

--- a/modules/chat/tests/utils/generateRandomMessage.test.ts
+++ b/modules/chat/tests/utils/generateRandomMessage.test.ts
@@ -1,0 +1,9 @@
+import { generateRandomMessage } from '../../utils/generateRandomMessage'
+
+describe('generate random message', () => {
+  it('should return a random string', () => {
+    const res = generateRandomMessage()
+
+    expect(typeof res).toBe('string')
+  })
+})

--- a/modules/chat/utils/generateRandomMessage.ts
+++ b/modules/chat/utils/generateRandomMessage.ts
@@ -1,0 +1,12 @@
+import { faker } from '@faker-js/faker'
+import { getRandomArrayItem } from '../../../utils/arrays'
+
+const messageProviders: Array<() => string> = [
+  faker.lorem.sentence,
+  faker.lorem.word,
+  faker.lorem.paragraph
+]
+
+export const generateRandomMessage = (): string => {
+  return getRandomArrayItem(messageProviders)()
+}

--- a/modules/chat/utils/getRandomChat.ts
+++ b/modules/chat/utils/getRandomChat.ts
@@ -4,7 +4,7 @@ import ChatMessage from '../consts/ChatMessage'
 import ChatRandomResponse from '../consts/ChatRandomResponse'
 import { generateRandomMessage } from './generateRandomMessage'
 
-export const getRandomChat = (userCount: number, messageCount: number): ChatRandomResponse => {
+export const getRandomChat = (userCount: number, messageCount: number, various: boolean = false): ChatRandomResponse => {
   const users = getRandomUsers(userCount)
 
   const messages: ChatMessage[] = []
@@ -12,7 +12,7 @@ export const getRandomChat = (userCount: number, messageCount: number): ChatRand
     messages.push({
       id: faker.datatype.uuid(),
       createdAt: faker.date.recent(faker.datatype.number({ min: 0, max: 30 })).toISOString(),
-      message: generateRandomMessage(),
+      message: various ? generateRandomMessage() : faker.lorem.sentence(),
       userId: users[faker.datatype.number({ min: 0, max: userCount - 1 })].userId
     })
   })

--- a/modules/chat/utils/getRandomChat.ts
+++ b/modules/chat/utils/getRandomChat.ts
@@ -1,22 +1,23 @@
-import { faker } from "@faker-js/faker";
-import getRandomUsers from "../../users/utils/getRandomUsers";
-import ChatMessage from "../consts/ChatMessage";
-import ChatRandomResponse from "../consts/ChatRandomResponse";
+import { faker } from '@faker-js/faker'
+import getRandomUsers from '../../users/utils/getRandomUsers'
+import ChatMessage from '../consts/ChatMessage'
+import ChatRandomResponse from '../consts/ChatRandomResponse'
+import { generateRandomMessage } from './generateRandomMessage'
 
-export const getRandomChat = (userCount : number, messageCount: number) : ChatRandomResponse => {
-    const users = getRandomUsers(userCount);
+export const getRandomChat = (userCount: number, messageCount: number): ChatRandomResponse => {
+  const users = getRandomUsers(userCount)
 
-    const messages : ChatMessage[] = [];
-    Array.from({length: messageCount}).forEach(() => {
-        messages.push({
-            id: faker.datatype.uuid(),
-            createdAt: faker.date.recent(faker.datatype.number({ min: 0, max: 30 })).toISOString(),
-            message: faker.lorem.sentence(),
-            userId: users[faker.datatype.number({ min: 0, max: userCount - 1 })].userId,
-        })
+  const messages: ChatMessage[] = []
+  Array.from({ length: messageCount }).forEach(() => {
+    messages.push({
+      id: faker.datatype.uuid(),
+      createdAt: faker.date.recent(faker.datatype.number({ min: 0, max: 30 })).toISOString(),
+      message: generateRandomMessage(),
+      userId: users[faker.datatype.number({ min: 0, max: userCount - 1 })].userId
     })
-    return {
-        users,
-        messages
-    }
+  })
+  return {
+    users,
+    messages
+  }
 }


### PR DESCRIPTION
I added a new `/chat/random/various` (and `/chat/random/various/{userCount}/{messageCount}`)  routes to have various type of messages, the test, the doc, all from the issue #16 
Tell me if it's good for you !
And btw it's for Hacktoberfest !