### PR TITLE
YAML error in Address module

### DIFF
--- a/modules/address/api/address-routes.ts
+++ b/modules/address/api/address-routes.ts
@@ -4,89 +4,90 @@ import getRandomAddresses from '../utils/getRandomAddress';
 import { getQtyFromRequest } from '../../../utils/route-utils';
 import { getCountryNameFromRequest } from '../../../utils/route-utils';
 
+
+
+// get a random address (by default, a USA format address is returned)
+
 module.exports = function(app : core.Express) {
+    /**
+     * @openapi
+     * /address:
+     *   get:
+     *     tags:
+     *       - Address
+     *     summary: Obtain a USA address (by default)
+     *     responses:
+     *       200:
+     *         description: An array of single address string
+     *         content:
+     *           application/json:
+     *             schema:
+     *               type: array
+     *               example: ['Andrew Kappa\n3686 Capital Lakeview\nLahore 2344\nUSA']
+     */
+    app.get('/address', (req: Request, res: Response) => {
+        const address = getRandomAddresses();
+        res.json(address);
+    });
 
-	// get a random address (by default, a USA format address is returned)
+    // get a random UK/USA address
+    /**
+     * @openapi
+     * '/address/:country':
+     *   get:
+     *     tags:
+     *     - Address
+     *     summary: Obtain a random UK/USA address
+     *     parameters:
+     *       - in: path 
+     *         name: country
+     *         description: The country whose address is required; can be 'usa' or 'uk'
+     *         type: string
+     *     responses:
+     *       '200':
+     *          description: An array of single address string
+     *          schema:
+     *            type: array
+     *            items:
+     *              type: string
+     *              example: ['Andrew Kappa\n3686 Capital Lakeview\nLahore 2344\nUSA']
+     */
+    app.get('/address/:country?', (req: Request, res: Response) => {
+        const country = getCountryNameFromRequest(req);
+        const address = getRandomAddresses(1, country);
+        res.json(address);
+    });
 
-	/**
-	 * @openapi
-	 * "/address":
-	 *   get:
-	 *     tags:
-	 *     - Address
-	 *     summary: Obtain a USA address (by default)
-	 *     responses:
-	 *       '200':
-	 *         description: An array of single address string
-	 * 		   schema:
-	 *           type: array
-	 *           items:
-	 *             type: string
-	 *             example: ['Andrew Kappa\n3686 Capital Lakeview\nLahore 2344\nUSA']
-	 */
-	app.get('/address', (req: Request, res: Response) => {
-		const address = getRandomAddresses();
-		res.json(address);
-	});
-
-	// get a random UK/USA address
-	/**
-	 * @openapi
-	 * '/address/:country':
-	 *   get:
-	 *     tags:
-	 *     - Address
-	 *     summary: Obtain a random UK/USA address
-	 *     parameters:
-	 *       - name: country 
-	 *         in: path
-	 *         description: The country whose address is required; can be 'usa' or 'uk'
-	 *         type: string
-	 *     responses:
-	 *       '200':
-	 *          description: An array of single address string
-	 *          schema:
-	 *            type: array
-	 *            items:
-	 *              type: string
-	 *              example: ['Andrew Kappa\n3686 Capital Lakeview\nLahore 2344\nUSA']
-	 */
-	app.get('/address/:country?', (req: Request, res: Response) => {
-		const country = getCountryNameFromRequest(req);
-		const address = getRandomAddresses(1, country);
-		res.json(address);
-	});
-
-	// get random USA/UK addresses
-	/**
-	 * @openapi
-	 * '/address/:country/:qty':
-	 *   get:
-	 *     tags:
-	 *     - Addresses
-	 *     summary: Obtain random UK/USA addresses
-	 *     parameters:
-	 *       - name: country 
-	 *         in: path
-	 *         description: The country whose address is required; can be 'usa' or 'uk'
-	 *         type: string
-	 *      - name: qty 
-	 *         in: path
-	 *         description: The number of addresses required
-	 *         type: number
-	 *     responses:
-	 *       '200':
-	 *          description: An array of address strings
-	 *          schema:
-	 *            type: array
-	 *            items:
-	 *              type: string
-	 *              example: ['Andrew Kappa\n3686 Capital Lakeview\nLahore 2344\nUSA', 'Jamal Khan\n600 Zumbuli House\nWashingtom 44521\nUSA']
-	 */
-	app.get('/address/:country?/:qty?', (req: Request, res: Response) => {
-		const country = getCountryNameFromRequest(req);
-		const qty = getQtyFromRequest(req);
-		const addresses = getRandomAddresses(qty, country);
-		res.json(addresses);
-	});
+    // get random USA/UK addresses
+    /**
+     * @openapi
+     * '/address/:country/:qty':
+     *   get:
+     *     tags:
+     *     - Addresses
+     *     summary: Obtain random UK/USA addresses
+     *     parameters:
+     *       - in: path 
+     *         name: country
+     *         description: The country whose address is required; can be 'usa' or 'uk'
+     *         type: string
+     *       - in: path 
+     *         name: qty
+     *         description: The number of addresses required
+     *         type: number
+     *     responses:
+     *       '200':
+     *          description: An array of address strings
+     *          schema:
+     *            type: array
+     *            items:
+     *              type: string
+     *              example: ['Andrew Kappa\n3686 Capital Lakeview\nLahore 2344\nUSA', 'Jamal Khan\n600 Zumbuli House\nWashingtom 44521\nUSA']
+     */
+    app.get('/address/:country?/:qty?', (req: Request, res: Response) => {
+        const country = getCountryNameFromRequest(req);
+        const qty = getQtyFromRequest(req);
+        const addresses = getRandomAddresses(qty, country);
+        res.json(addresses);
+    });
 }

--- a/modules/address/api/address-routes.ts
+++ b/modules/address/api/address-routes.ts
@@ -64,7 +64,7 @@ module.exports = function(app : core.Express) {
      * '/address/:country/:qty':
      *   get:
      *     tags:
-     *     - Addresses
+     *     - Address
      *     summary: Obtain random UK/USA addresses
      *     parameters:
      *       - in: path 

--- a/modules/animal/api/animal-routes.ts
+++ b/modules/animal/api/animal-routes.ts
@@ -4,6 +4,7 @@ import { getQtyFromRequest } from '../../../utils/route-utils';
 import AnimalType from '../consts/AnimalEnum';
 import getSpeciesOfAnimal from '../utils/getSpeciesOfAnimal';
 
+
 module.exports = function (app: core.Express) {
     /**
      * @openapi

--- a/modules/currency/tests/api/currency-routes.test.ts
+++ b/modules/currency/tests/api/currency-routes.test.ts
@@ -5,7 +5,7 @@ describe('currency api endpoints', () => {
     describe('GET /currencies/digital-coins/ethereum/tx-list', () => {
         it('should return a list of transactions performed by an address', async () => {
             const qty = 10;
-            const response = await request(baseURL).get(`/currencies/digital-coins/ethereum/tx-list/0xc5102fE9359FD9a28f877a67E36B0F050d81a3CC/${qty}`);
+            const response = await request(app).get(`/currencies/digital-coins/ethereum/tx-list/0xc5102fE9359FD9a28f877a67E36B0F050d81a3CC/${qty}`);
 
             expect(response.body.length).toBe(qty);
         });

--- a/modules/products/test/api/products-routes.test.ts
+++ b/modules/products/test/api/products-routes.test.ts
@@ -53,10 +53,9 @@ describe('products api endpoints', () => {
     describe('GET /products/quantity/:qty', () => {
         const quantity = 4;
 
-        it('should return a list of products ', async () => {
-            const response = await request(app).get(`/products/quantity/${quantity}`);
+        it('should return a list of products', async () => {
+            const response = await request(app).get(`/products/${quantity}`);
             expect(response.body.length).toEqual(quantity);
-
         });
     });
 
@@ -66,7 +65,6 @@ describe('products api endpoints', () => {
         it('should return a list of products', async () => {
             const response = await request(app).get(`/products/department/${department}`);
             expect(response.body[0].department).toEqual(department);
-
         });
     });
 

--- a/modules/sports/tests/api/sports-routes.test.ts
+++ b/modules/sports/tests/api/sports-routes.test.ts
@@ -13,7 +13,7 @@ describe('sports api endpoints', () => {
     describe('GET /sports/football/leagues/laliga/teams', () => {
         it('should return a list of la liga teams', async () => {
             const qty = 20;
-            const response = await request(baseURL).get(`/sports/football/leagues/laliga/teams/${qty}`);
+            const response = await request(app).get(`/sports/football/leagues/laliga/teams/${qty}`);
 
             expect(response.body.length).toBe(qty);
         });

--- a/utils/swagger.ts
+++ b/utils/swagger.ts
@@ -1,6 +1,4 @@
-import { Express, Request, Response } from 'express';
 import swaggerJsdoc from 'swagger-jsdoc';
-import swaggerUi from 'swagger-ui-express';
 
 const { version } = require('../package.json');
 
@@ -19,6 +17,10 @@ const options: swaggerJsdoc.Options = {
         consumes: ['application/json'],
         produces: ['application/json'],
         tags: [
+            {
+                name: 'Address',
+                description: 'A set of endpoints related to addresses',
+            },
             {
                 name: 'Animals',
                 description: 'A set of endpoints related to animal',


### PR DESCRIPTION
Resolved error for issue #201 

Restructured address module swagger YAML configuration.
Updated the currency and sports api tests to use `app` instead of `baseURL` which does not work.

Now no more YAML errors when running tests and server.