### PR TITLE
add endpoint for Ripple ledger mocks

### DIFF
--- a/src/modules/currency/api/currency-routes.ts
+++ b/src/modules/currency/api/currency-routes.ts
@@ -8,45 +8,6 @@ import getDigitalCurrencyTxList from '../utils/getDigitalCurrencyTxList';
 import getDigitalCurrencyLedger from '../utils/getDigitalCurrencyLedger'
 import DigitalCoinEnum from '../consts/DigitalCoinEnum';
 
-
-/**
- * @openapi
- * definitions:
- *   MockedRippleLedger:
- *     type: object
- *     properties:
- *       ledger_index:
- *         type: string
- *         example: '102356562'
- *       ledger_hash:
- *         type: string
- *         example: 'E9BE2BF76B567E19FE8EA07E44AD84657287248E66221177F529575FC9DE1006'
- *       close_flags:
- *         type: string
- *         example: '0'
- *       close_time:
- *         type: string
- *         example: '1666137175651'
- *       close_time_human:
- *         type: string
- *         example: '2022-10-18T23:52:55.651Z'
- *       parent_hash:
- *         type: string
- *         example: '6977BD8B25BAB7FEBB965CC0E57783773723E096207CA716220D36A5381EA6BD'
- *       transaction_hash:
- *         type: string
- *         example: '4402A59390C12C4EA5841DA69A4B6BCB77C9B5C3BE5C770FAA731FCE090139F4'
- *       tx_count:
- *         type: string
- *         example: '85'
- *       total_coins:
- *         type: string
- *         example: '99924240361351122'
- *       destroyed_coins:
- *         type: string
- *         example: '-70612'
- */
-
 module.exports = function (app: core.Express) {
     /**
      * @openapi

--- a/src/modules/currency/api/currency-routes.ts
+++ b/src/modules/currency/api/currency-routes.ts
@@ -5,7 +5,47 @@ import GBP_USD_TICKER_DATA from '../data/gbp-usd-ticker-data';
 import { getQtyFromRequest } from '../../../utils/route-utils';
 import getDigitalCurrencyAddress from '../utils/getDigitalCurrencyAddress';
 import getDigitalCurrencyTxList from '../utils/getDigitalCurrencyTxList';
+import getDigitalCurrencyLedger from '../utils/getDigitalCurrencyLedger'
 import DigitalCoinEnum from '../consts/DigitalCoinEnum';
+
+
+/**
+ * @openapi
+ * definitions:
+ *   MockedRippleLedger:
+ *     type: object
+ *     properties:
+ *       ledger_index:
+ *         type: string
+ *         example: '102356562'
+ *       ledger_hash:
+ *         type: string
+ *         example: 'E9BE2BF76B567E19FE8EA07E44AD84657287248E66221177F529575FC9DE1006'
+ *       close_flags:
+ *         type: string
+ *         example: '0'
+ *       close_time:
+ *         type: string
+ *         example: '1666137175651'
+ *       close_time_human:
+ *         type: string
+ *         example: '2022-10-18T23:52:55.651Z'
+ *       parent_hash:
+ *         type: string
+ *         example: '6977BD8B25BAB7FEBB965CC0E57783773723E096207CA716220D36A5381EA6BD'
+ *       transaction_hash:
+ *         type: string
+ *         example: '4402A59390C12C4EA5841DA69A4B6BCB77C9B5C3BE5C770FAA731FCE090139F4'
+ *       tx_count:
+ *         type: string
+ *         example: '85'
+ *       total_coins:
+ *         type: string
+ *         example: '99924240361351122'
+ *       destroyed_coins:
+ *         type: string
+ *         example: '-70612'
+ */
 
 module.exports = function (app: core.Express) {
     /**
@@ -160,6 +200,33 @@ module.exports = function (app: core.Express) {
         const qty = getQtyFromRequest(req);
         const tx_list = getDigitalCurrencyTxList(address, qty);
         res.json(tx_list);
+    })
+    
+    /**
+     * @openapi
+     * '/currencies/digital-coins/ripple/ledgers-list/{qty}':
+     *   get:
+     *     tags:
+     *     - Currencies
+     *     summary: Returns a random set of Ripple (XPR) Validated Ledgers
+     *     parameters:
+     *     - in: path
+     *       name: qty
+     *       description: The amount of ledgers you require
+     *       type: string
+     *       default: 10
+     *     responses:
+     *       '200':
+     *         description: OK
+     *         schema:
+     *           type: array
+     *           items:
+     *             $ref: '#/definitions/MockedRippleLedger'
+     */
+    app.get("/currencies/digital-coins/ripple/ledgers-list/:qty?", (req: Request, res: Response) => {
+        const qty = getQtyFromRequest(req);
+        const ledger = getDigitalCurrencyLedger(qty);
+        res.json(ledger);
     })
 
 }

--- a/src/modules/currency/consts/LedgerInfo.ts
+++ b/src/modules/currency/consts/LedgerInfo.ts
@@ -1,0 +1,14 @@
+interface ledgerInfo {
+    ledger_index: string;
+    ledger_hash: string;
+    close_flags: string;
+    close_time: string;
+    close_time_human: string;
+    parent_hash: string;
+    transaction_hash: string;
+    tx_count: string;
+    total_coins: string;
+    destroyed_coins: string;
+}
+
+export default ledgerInfo;

--- a/src/modules/currency/consts/LedgerInfo.ts
+++ b/src/modules/currency/consts/LedgerInfo.ts
@@ -1,3 +1,41 @@
+/**
+ * @openapi
+ * definitions:
+ *   MockedRippleLedger:
+ *     type: object
+ *     properties:
+ *       ledger_index:
+ *         type: string
+ *         example: '102356562'
+ *       ledger_hash:
+ *         type: string
+ *         example: 'E9BE2BF76B567E19FE8EA07E44AD84657287248E66221177F529575FC9DE1006'
+ *       close_flags:
+ *         type: string
+ *         example: '0'
+ *       close_time:
+ *         type: string
+ *         example: '1666137175651'
+ *       close_time_human:
+ *         type: string
+ *         example: '2022-10-18T23:52:55.651Z'
+ *       parent_hash:
+ *         type: string
+ *         example: '6977BD8B25BAB7FEBB965CC0E57783773723E096207CA716220D36A5381EA6BD'
+ *       transaction_hash:
+ *         type: string
+ *         example: '4402A59390C12C4EA5841DA69A4B6BCB77C9B5C3BE5C770FAA731FCE090139F4'
+ *       tx_count:
+ *         type: string
+ *         example: '85'
+ *       total_coins:
+ *         type: string
+ *         example: '99924240361351122'
+ *       destroyed_coins:
+ *         type: string
+ *         example: '-70612'
+ */
+
 interface ledgerInfo {
     ledger_index: string;
     ledger_hash: string;

--- a/src/modules/currency/tests/utils/api/currency-routes.test.ts
+++ b/src/modules/currency/tests/utils/api/currency-routes.test.ts
@@ -47,4 +47,13 @@ describe('currency api endpoints', () => {
             expect(response.body.length).toBe(qty);
         });
     });
+
+    describe('GET currencies/digital-coins/ripple/ledgers-list/:qty?', () => {
+        it('should return a list of Ripple ledgers', async () => {
+            const qty = 5;
+            const response = await request(app).get(`/currencies/digital-coins/ripple/ledgers-list/${qty}`);
+
+            expect(response.body.length).toBe(qty);
+        });
+    });
 });

--- a/src/modules/currency/utils/getDigitalCurrencyLedger.ts
+++ b/src/modules/currency/utils/getDigitalCurrencyLedger.ts
@@ -1,0 +1,54 @@
+import ledgerInfo from '../consts/LedgerInfo';
+
+const getDigitalCurrencyLedger = ( amount: number) : ledgerInfo[] => {
+  const XPR_TRANS_LIST = []
+  const getDate = new Date();
+
+    for (let i = 0; i < amount; i++) {
+      let transaction: ledgerInfo = {
+        ledger_index:  (Math.floor(Math.random() * 99999999) + 10000000).toString(),
+        ledger_hash: (generateSHA512HalfHash(64)).toString(),
+        close_flags: "0",
+        close_time: getDate.getTime().toString(),
+        close_time_human: getDate.toISOString(),
+        parent_hash: (generateSHA512HalfHash(64)).toString(),
+        transaction_hash: (generateSHA512HalfHash(64)).toString(),
+        tx_count: (Math.floor(Math.random() * 100)).toString(),
+        total_coins: `999${generateCoins(14)}`,
+        destroyed_coins: `-${randomIntegerFromRange(1000, 100000).toString()}`
+      }
+
+      XPR_TRANS_LIST.push(transaction);        
+    }
+
+  return XPR_TRANS_LIST;
+}
+
+// https://xrpl.org/basic-data-types.html#hashes
+function generateSHA512HalfHash(length: number) {
+    let result = '';
+    const characters = 'ABCDEF0123456789';
+    const charactersLength = characters.length;
+
+    for ( var i = 0; i < length; i++ ) {
+      result += characters.charAt(Math.floor(Math.random() *  charactersLength));
+    }
+
+    return result;
+}
+
+function generateCoins(length: number) {
+    let coins = '';
+    
+    for (let i = 0; i < length; i++) {
+      coins += Math.floor(Math.random() * (length/2));
+    }
+
+    return coins;
+}
+
+function randomIntegerFromRange(min: number, max: number) {
+  return Math.floor(Math.random() * (max - min + 1) + min)
+}
+
+export default getDigitalCurrencyLedger;

--- a/swagger.json
+++ b/swagger.json
@@ -853,6 +853,34 @@
                 }
             }
         },
+        "/currencies/digital-coins/ripple/ledgers-list/{qty}": {
+            "get": {
+                "tags": [
+                    "Currencies"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "qty",
+                        "description": "The amount of ledgers you require",
+                        "type": "string",
+                        "default": 10
+                    }
+                ],
+                "summary": "Returns a random set of Ripple (XPR) Validated Ledgers",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/emails": {
             "get": {
                 "tags": [


### PR DESCRIPTION
Create new currency endpoint to generate x Ripple (XDP) ledgers `currencies/digital-coins/ripple/ledgers-list/{qty}`

Based on response object from Validated Ledgers: https://xrpscan.com/

Added as part of #14 