### PR TITLE
add a=>z sorting with swaggerOptions

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -55,9 +55,18 @@ app.get('/docs.json', (req: Request, res: Response) => {
     res.send(swaggerSpec);
 });
 
+
+const schemaOptions = {
+    swaggerOptions: {
+        dom_id: "#swagger-ui",
+        tagsSorter: "alpha",
+        operationsSorter: "alpha"
+    }
+};
+
 // Setup Swagger API Documentation
 const swaggerUi = require('swagger-ui-express');
-app.use('/', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+app.use('/', swaggerUi.serve, swaggerUi.setup(swaggerSpec, schemaOptions));
 
 app.use(cors()); // enabling CORS for all requests
 app.use(morgan('combined')); // adding morgan to log HTTP requests


### PR DESCRIPTION
Created `schemaOptions` to pass to `swaggerUi`. Sorts the schemas A=>Z.

Resolves #242 

```javascript
const schemaOptions = {
    swaggerOptions: {
        dom_id: "#swagger-ui",
        tagsSorter: "alpha",
        operationsSorter: "alpha"
    }
};
```