### PR TITLE
Feat: Digital currency address balance endpoint

### DIFF
--- a/modules/currency/api/currency-routes.ts
+++ b/modules/currency/api/currency-routes.ts
@@ -186,7 +186,16 @@ module.exports = function (app: core.Express) {
      *           type: json
      *           items:
      *             type: object
-     *             example: {"address":"0xc0ffee254729296a45a3885639AC7E10F9d54979","amount":267.706,"unit":"BTC"}
+     *             properties:
+     *              address:
+     *                  type: string
+     *                  example: 0xc0ffee254729296a45a3885639AC7E10F9d54979
+     *              amount:
+     *                  type: number
+     *                  example: 267.706
+     *              unit:
+     *                  type: string
+     *                  example: ETH
      */
 
     //Returns the balance (with unit) of a given address

--- a/modules/currency/api/currency-routes.ts
+++ b/modules/currency/api/currency-routes.ts
@@ -6,6 +6,7 @@ import { getQtyFromRequest } from '../../../utils/route-utils';
 import getDigitalCurrencyAddress from '../utils/getDigitalCurrencyAddress';
 import getDigitalCurrencyTxList from '../utils/getDigitalCurrencyTxList';
 import DigitalCoinEnum from '../consts/DigitalCoinEnum';
+import getDigitalCurrencyBalance from '../utils/GetDigitalCurrencyBalance';
 
 module.exports = function (app: core.Express) {
     /**
@@ -160,6 +161,14 @@ module.exports = function (app: core.Express) {
         const qty = getQtyFromRequest(req);
         const tx_list = getDigitalCurrencyTxList(address, qty);
         res.json(tx_list);
+    })
+
+    app.get("/currencies/digital-coins/balance/:network?/:address?", (req: Request, res: Response) => {
+        const network = req.params.network;
+        const address = req.params.address;
+        const addressBalance = getDigitalCurrencyBalance(network, address);
+        res.json(addressBalance);
+
     })
 
 }

--- a/modules/currency/api/currency-routes.ts
+++ b/modules/currency/api/currency-routes.ts
@@ -186,7 +186,7 @@ module.exports = function (app: core.Express) {
      *           type: json
      *           items:
      *             type: object
-     *             example: {"amount":403.01,"unit":"ETH"}
+     *             example: {"address":"0xc0ffee254729296a45a3885639AC7E10F9d54979","amount":267.706,"unit":"BTC"}
      */
 
     //Returns the balance (with unit) of a given address

--- a/modules/currency/api/currency-routes.ts
+++ b/modules/currency/api/currency-routes.ts
@@ -163,6 +163,33 @@ module.exports = function (app: core.Express) {
         res.json(tx_list);
     })
 
+    /**
+     * @openapi
+     * '/currencies/digital-coins/balance/:network?/:address?':
+     *   get:
+     *     tags:
+     *     - Currency
+     *     summary: Get the balance of an address
+     *     parameters:
+     *     - in: path
+     *       name: network
+     *       description: The network the address has a balance on (Currently 10 networks supported, view data/digital-currency-units.ts)
+     *       type: string
+     *     - in: path
+     *       name: address
+     *       description: The address that contains the balance
+     *       type: string
+     *     responses:
+     *       '200':
+     *         description: OK
+     *         schema:
+     *           type: json
+     *           items:
+     *             type: object
+     *             example: {"amount":403.01,"unit":"ETH"}
+     */
+
+    //Returns the balance (with unit) of a given address
     app.get("/currencies/digital-coins/balance/:network?/:address?", (req: Request, res: Response) => {
         const network = req.params.network;
         const address = req.params.address;

--- a/modules/currency/consts/AddressBalance.ts
+++ b/modules/currency/consts/AddressBalance.ts
@@ -1,0 +1,6 @@
+interface addressBalance {
+    amount: number;
+    unit: string;
+}
+
+export default addressBalance;

--- a/modules/currency/consts/AddressBalance.ts
+++ b/modules/currency/consts/AddressBalance.ts
@@ -1,4 +1,5 @@
 interface addressBalance {
+    address: string;
     amount: number;
     unit: string;
 }

--- a/modules/currency/data/digital-currency-units.ts
+++ b/modules/currency/data/digital-currency-units.ts
@@ -1,0 +1,13 @@
+const digital_currency_units = {
+    "bitcoin": "BTC",
+    "ethereum": "ETH",
+    "tether": "USDT",
+    "xrp": "XRP",
+    "cardano": "ADA",
+    "solana": "SOL",
+    "polygon": "MATIC",
+    "litecoin": "LTC"
+
+}
+
+export default digital_currency_units;

--- a/modules/currency/tests/api/currency-routes.test.ts
+++ b/modules/currency/tests/api/currency-routes.test.ts
@@ -10,4 +10,15 @@ describe('currency api endpoints', () => {
             expect(response.body.length).toBe(qty);
         });
     });
+
+    describe('GET /currencies/digital-coins/balance/:network?/:address?', () => {
+        it('should return the balance of an address on a specified network', async () => {
+            const network = "ethereum";
+            const address = "0xc0ffee254729296a45a3885639AC7E10F9d54979"
+            const response = await request(app).get(`/currencies/digital-coins/balance/${network}/${address}`);
+
+            expect(response.body.unit).toBe("ETH");
+            expect(response.body.amount).toBeGreaterThan(0);
+        });
+    });
 });

--- a/modules/currency/tests/api/currency-routes.test.ts
+++ b/modules/currency/tests/api/currency-routes.test.ts
@@ -19,6 +19,7 @@ describe('currency api endpoints', () => {
 
             expect(response.body.unit).toBe("ETH");
             expect(response.body.amount).toBeGreaterThan(0);
+            expect(response.body.address).toBe(address);
         });
     });
 });

--- a/modules/currency/utils/GetDigitalCurrencyBalance.ts
+++ b/modules/currency/utils/GetDigitalCurrencyBalance.ts
@@ -3,7 +3,7 @@ import digital_currency_units from '../data/digital-currency-units';
 
 const getDigitalCurrencyBalance = (network: string, address: string) : addressBalance => {
 
-    const unit = digital_currency_units[address];
+    const unit = digital_currency_units[network];
     const amount: number = Number((Math.random() * (1000 - 0.001) + 0.001).toFixed(3));
 
     const addressBalance = {

--- a/modules/currency/utils/GetDigitalCurrencyBalance.ts
+++ b/modules/currency/utils/GetDigitalCurrencyBalance.ts
@@ -7,6 +7,7 @@ const getDigitalCurrencyBalance = (network: string, address: string) : addressBa
     const amount: number = Number((Math.random() * (1000 - 0.001) + 0.001).toFixed(3));
 
     const addressBalance = {
+        address: address,
         amount: amount,
         unit: unit,
     }

--- a/modules/currency/utils/GetDigitalCurrencyBalance.ts
+++ b/modules/currency/utils/GetDigitalCurrencyBalance.ts
@@ -1,0 +1,18 @@
+import addressBalance from '../consts/AddressBalance';
+import digital_currency_units from '../data/digital-currency-units';
+
+const getDigitalCurrencyBalance = (network: string, address: string) : addressBalance => {
+
+    const unit = digital_currency_units[address];
+    const amount: number = Number((Math.random() * (1000 - 0.001) + 0.001).toFixed(3));
+
+    const addressBalance = {
+        amount: amount,
+        unit: unit,
+    }
+
+    return addressBalance
+   
+}
+
+export default getDigitalCurrencyBalance;


### PR DESCRIPTION
**Endpoint Summary:**
Returns the balance and unit of an address

Related to https://github.com/ageddesi/Mocked-API/issues/14

**Endpoint Path:**
/currencies/digital-coins/balance/:network?/:address?

**Part of an Example Response:** 

```
{
"amount": 403.01,
"unit": "ETH"
}
```
