### PR TITLE
Fix issue #286 (Movie tests fail with certain movie id's generated)

### DIFF
--- a/src/modules/movies/api/movies-routes.ts
+++ b/src/modules/movies/api/movies-routes.ts
@@ -21,10 +21,8 @@ module.exports = function (app: core.Express) {
      *          $ref: '#/definitions/MockMovie'
      */
     app.get('/movies/random', (req: Request, res: Response) => {
-        const randomNumber = Math.floor(Math.random() * movies.length) + 1
-        const movie = getMovieById(randomNumber);
-
-        res.json(movie);
+        const movie = getRandomMovies(1);
+        res.json(movie[0]);
     });
 
     /**
@@ -51,7 +49,6 @@ module.exports = function (app: core.Express) {
     app.get('/movies/:qty?', (req: Request, res: Response) => {
         const quantity = getQtyFromRequest(req, 10);
         const movies = getRandomMovies(quantity);
-
         return res.json(movies);
     });
 


### PR DESCRIPTION
# Pull request template
## Describe your changes
During testing for the Analytics PR (see [this action](https://github.com/ageddesi/Mocked-API/actions/runs/3358220292/jobs/5564879887)) the movies test for get random movie failed.    Some brief analysis revealed that this end point was returning a movie based on a randomly generated ID, based on the number of records in the [data file](https://github.com/ageddesi/Mocked-API/blob/ad467cfe102faee6d2d2137a6058203dc54da3dd/src/modules/movies/data/movies.ts).

Instead I have refactored the endpoint to return a single random movie, using the existing [getRandomMovies](https://github.com/ageddesi/Mocked-API/blob/ad467cfe102faee6d2d2137a6058203dc54da3dd/src/modules/movies/utils/getRandomMovies.ts#L4)

As this method pulls a single movie out of the collection, then this won't be affected by the missing record ID identified in the issue.

## Link to issue this resolves
Fixes: #286

