### PR TITLE
feat(emails): add endpoint for random email using user names

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mocked-api",
-  "version": "0.18.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mocked-api",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "ISC",
       "dependencies": {
         "@sentry/node": "^7.17.4",
@@ -5960,6 +5960,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/optionator": {
       "version": "0.9.1",

--- a/api/src/modules/emails/api/emails-routes.ts
+++ b/api/src/modules/emails/api/emails-routes.ts
@@ -1,13 +1,14 @@
 import { Request, Response } from 'express';
 import * as core from 'express-serve-static-core';
 import { getRandomEmails } from '../utils/getRandomEmails';
+import {getRandomEmailByUsername} from "../utils/getRandomEmailByUsername";
 
 const defaultEmailCount = 10;
 
 module.exports = function (app: core.Express) {
     /**
      * @openapi
-     * '/email':
+     * '/emails':
      *   get:
      *     tags:
      *     - Emails
@@ -20,5 +21,47 @@ module.exports = function (app: core.Express) {
      */
     app.get('/emails', (req: Request, res: Response) => {
         res.json(getRandomEmails(defaultEmailCount));
+    });
+
+    /**
+     * @openapi
+     * '/email':
+     *   get:
+     *     tags:
+     *     - Email
+     *     summary: Returns a movk of email using first and last name
+     *     parameters:
+     *       - in: query
+     *         name: firstName
+     *         required: true
+     *         schema:
+     *           type: string
+     *         description: The first name of the user
+     *       - in: query
+     *         name: lastName
+     *         required: true
+     *         schema:
+     *           type: string
+     *         description: The last name of the user
+     *     responses:
+     *       '200':
+     *         description: OK
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/definitions/MockEmails'
+     *       '400':
+     *         description: Bad Request
+     *         content:
+     *           application/json:
+     */
+
+    app.get('/emails/address', (req: Request, res: Response) => {
+        const firstName = req.query.firstName as string;
+        const lastName = req.query.lastName as string;
+        if (!firstName || !lastName) {
+            return res.status(400).json({ error: 'firstName and lastName are required' });
+        }
+        res.json(getRandomEmailByUsername( firstName.toLowerCase(), lastName.toLowerCase()));
     });
 };

--- a/api/src/modules/emails/tests/api/emails-routes.test.ts
+++ b/api/src/modules/emails/tests/api/emails-routes.test.ts
@@ -15,4 +15,35 @@ describe('emails api endpoints', () => {
             expect(response.body[0]).toHaveProperty('date');
         });
     });
+
+    describe('GET /emails/address', () => {
+        it('should return a random email', async () => {
+            const response = await request(app).get(`/emails/address`)
+                .query({firstName: 'John', lastName: 'Cena'})
+                .expect(200).expect('Content-Type', /json/);
+
+            expect(response.body).toContain('john');
+            expect(response.body).toMatch(/^[^\s@]+@[^\s@]+\.[^\s@]+$/);
+        });
+        it('should return 400 error', async () => {
+            const response = await request(app).get(`/emails/address`)
+                .query({firstName: 'John'})
+                .expect(400).expect('Content-Type', /json/);
+
+            expect(response.body).toEqual({"error": "firstName and lastName are required"});
+        });
+        it('should return 400 error', async () => {
+            const response = await request(app).get(`/emails/address`)
+                .query({lastName: 'Cena'})
+                .expect(400).expect('Content-Type', /json/);
+
+            expect(response.body).toEqual({"error": "firstName and lastName are required"});
+        });
+        it('should return 400 error', async () => {
+            const response = await request(app).get(`/emails/address`)
+                .expect(400).expect('Content-Type', /json/);
+
+            expect(response.body).toEqual({"error": "firstName and lastName are required"});
+        });
+    });
 });

--- a/api/src/modules/emails/utils/getRandomEmailByUsername.ts
+++ b/api/src/modules/emails/utils/getRandomEmailByUsername.ts
@@ -1,0 +1,6 @@
+import { faker } from '@faker-js/faker';
+import Email from '../consts/Email';
+
+export const getRandomEmailByUsername = (firstName: string, lastName:string): string => {
+    return faker.internet.email(firstName,lastName);
+};


### PR DESCRIPTION
# Pull request template

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Describe your changes
this add an endpoint for generating random emails based on given first name and last name

## Link to issue this resolves
#81 
